### PR TITLE
Feat: Allow for different authentication flows

### DIFF
--- a/config/zoho.php
+++ b/config/zoho.php
@@ -28,9 +28,21 @@ return [
     |--------------------------------------------------------------------------
     |
     | Zoho's token for OAuth process
+    | Depending on $auth_flow_type (see below) this could be a grantToken, refreshToken or accessToken
     |
     */
     'token' => env('ZOHO_TOKEN', null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Flow Type
+    |--------------------------------------------------------------------------
+    |
+    | Which authentication flow to use
+    | Zoho SDK Supports grantToken, refreshToken and accessToken
+    |
+    */
+    'auth_flow_type' => env('ZOHO_AUTH_FLOW_TYPE', 'grantToken'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Zoho.php
+++ b/src/Zoho.php
@@ -82,12 +82,31 @@ class Zoho
                                           ->filePath(config('zoho.application_log_file_path'))
                                           ->build();
 
-        $token = (new OAuthBuilder())
-            ->clientId(config('zoho.client_id'))
-            ->clientSecret(config('zoho.client_secret'))
-            ->grantToken($code ?? config('zoho.token'))
-            ->redirectURL(config('zoho.redirect_uri'))
-            ->build();
+        switch (config('zoho.auth_flow_type')) {
+            case 'accessToken':
+                $token = (new OAuthBuilder())
+                    ->accessToken(config('zoho.token'))
+                    ->build();
+                break;
+
+            case 'refreshToken':
+                $token = (new OAuthBuilder())
+                    ->clientId(config('zoho.client_id'))
+                    ->clientSecret(config('zoho.client_secret'))
+                    ->refreshToken($code ?? config('zoho.token'))
+                    ->redirectURL(config('zoho.redirect_uri'))
+                    ->build();
+                break;
+
+            default: // As in 'grantToken' <- was the only option before this change
+                $token = (new OAuthBuilder())
+                    ->clientId(config('zoho.client_id'))
+                    ->clientSecret(config('zoho.client_secret'))
+                    ->grantToken($code ?? config('zoho.token'))
+                    ->redirectURL(config('zoho.redirect_uri'))
+                    ->build();
+                break;
+        }
 
         $sdkConfig = (new SDKConfigBuilder())
             ->autoRefreshFields(config('zoho.autoRefreshFields'))


### PR DESCRIPTION
... as provided by the sdk. Default to the currently used grantToken and add .env based configuration to allow refreshToken and accessToken based authentication.

See issue #15 for discussion